### PR TITLE
single row legend

### DIFF
--- a/R/plot_hru_pw.R
+++ b/R/plot_hru_pw.R
@@ -94,7 +94,8 @@ plot_hru_pw_day <- function(sim_verify, hru_id, var, years = 1900:2100, add_crop
           strip.background = element_blank(),
           strip.placement = 'outside',
           strip.text = element_text(face = 'bold'),
-          axis.title.y = element_blank())
+          axis.title.y = element_blank())+
+    guides(color = guide_legend(nrow = 1))
 
   if (add_crop) {
     crop_dates <- sim_verify$mgt_out %>%


### PR DESCRIPTION
this change makes the hru legend only have 1 row. As this is a horizontal-based plot I think this makes more sense. Of course the HRUs might be off screen if there are too many for the width, so i am not sure about this change.. Up to you. @biopsichas