### PR TITLE
Fix linux functionality

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -32,7 +32,7 @@ get_os <- function() {
 #' @keywords internal
 #'
 run_os <- function(exe, os) {
-  if(os == 'unix') exe <- '.'%//%exe
+  if(os == 'unix' | os == "linux") exe <- paste0("./", exe)
   return(exe)
 }
 
@@ -50,9 +50,8 @@ find_swat_exe <- function(project_path, os) {
       .[grepl(".exe$",.)]
 
   } else if(os == "linux") {
-    swat_exe <- system("find"%&&%project_path%&&%"-executable -type f",
-                       intern = T) %>%
-      basename(.)
+    swat_exe <- system(paste0("find ", project_path, ".run_verify", " -executable -type f"),
+                       intern = T) %>% basename(.)
   } else if (os == 'osx') {
     stop('Functionality not tested for Mac. Therefore run aborted')
   }


### PR DESCRIPTION
For me, these changes allowed the function to run on linux (ubuntu).

Regarding the changes to string concatenation:  I guess its because I don't have the `pasta` package from Chris. (its also not imported anywhere, that could be another solution)

But that has since been removed from CRAN, so maybe its best to remove the dependency from SWATdoctR?

https://cran.r-project.org/package=pasta